### PR TITLE
67 fix image id usage consistency

### DIFF
--- a/yolo/tools/data_loader.py
+++ b/yolo/tools/data_loader.py
@@ -71,7 +71,7 @@ class YoloDataset(Dataset):
         labels_path, data_type = locate_label_paths(dataset_path, phase_name)
         images_list = sorted([p.name for p in Path(images_path).iterdir() if p.is_file()])
         if data_type == "json":
-            annotations_index, image_info_dict = create_image_metadata(labels_path)
+            annotations_dict, image_info_dict = create_image_metadata(labels_path)
 
         data = []
         valid_inputs = 0
@@ -81,10 +81,10 @@ class YoloDataset(Dataset):
             image_id = Path(image_name).stem
 
             if data_type == "json":
-                image_info = image_info_dict.get(image_id, None)
+                image_info = image_info_dict.get(image_name, None)
                 if image_info is None:
                     continue
-                annotations = annotations_index.get(image_info["id"], [])
+                annotations = annotations_dict.get(image_name, [])
                 image_seg_annotations = scale_segmentation(annotations, image_info)
                 if not image_seg_annotations:
                     continue
@@ -99,9 +99,7 @@ class YoloDataset(Dataset):
                 image_seg_annotations = []
 
             labels = self.load_valid_labels(image_id, image_seg_annotations)
-
-            img_path = images_path / image_name
-            data.append((img_path, labels))
+            data.append((image_name, labels))
             valid_inputs += 1
         logger.info("Recorded {}/{} valid inputs", valid_inputs, len(images_list))
         return data

--- a/yolo/tools/data_loader.py
+++ b/yolo/tools/data_loader.py
@@ -115,12 +115,18 @@ class YoloDataset(Dataset):
         logger.info("Recorded {}/{} valid inputs", valid_inputs, len(images_list))
         return data
 
-    def load_valid_labels(self, image_id: str, seg_data_one_img: list) -> Union[Tensor, None]:
+    def load_valid_labels(
+        self,
+        image_id: Union[int, str],
+        seg_data_one_img: list
+    ) -> Union[Tensor, None]:
         """
         Loads and validates bounding box data is [0, 1] from a label file.
 
         Parameters:
-            label_path (str): The filepath to the label file containing bounding box data.
+            image_id (int | str): Image id.
+            If COCO .json file is used, image id is a `int`.
+            If YOLO .txt file is used, image id is a string.
 
         Returns:
             Tensor or None: A tensor of all valid bounding boxes if any are found; otherwise, None.

--- a/yolo/tools/data_loader.py
+++ b/yolo/tools/data_loader.py
@@ -65,7 +65,8 @@ class YoloDataset(Dataset):
             labels_path (str): Path to the directory containing label files.
 
         Returns:
-            list: A list of tuples, each containing the path to an image file and its associated segmentation as a tensor.
+            list: A list of tuples, each containing the path to an image file
+                and its associated segmentation as a tensor.
         """
         images_path = dataset_path / "images" / phase_name
         labels_path, data_type = locate_label_paths(dataset_path, phase_name)
@@ -81,10 +82,10 @@ class YoloDataset(Dataset):
             image_id = Path(image_name).stem
 
             if data_type == "json":
-                image_info = image_info_dict.get(image_name, None)
+                image_info = image_info_dict.get(image_id, None)
                 if image_info is None:
                     continue
-                annotations = annotations_dict.get(image_name, [])
+                annotations = annotations_dict.get(image_id, [])
                 image_seg_annotations = scale_segmentation(annotations, image_info)
                 if not image_seg_annotations:
                     continue
@@ -99,7 +100,8 @@ class YoloDataset(Dataset):
                 image_seg_annotations = []
 
             labels = self.load_valid_labels(image_id, image_seg_annotations)
-            data.append((image_name, labels))
+            image_path = images_path / image_name
+            data.append((image_path, labels))
             valid_inputs += 1
         logger.info("Recorded {}/{} valid inputs", valid_inputs, len(images_list))
         return data

--- a/yolo/tools/solver.py
+++ b/yolo/tools/solver.py
@@ -237,7 +237,7 @@ class ModelValidator:
         self.model.eval()
         predict_json, mAPs = [], defaultdict(list)
         self.progress.start_one_epoch(len(dataloader), task="Validate")
-        for batch_size, images, targets, rev_tensor, img_paths in dataloader:
+        for batch_size, images, targets, rev_tensor, image_ids in dataloader:
             images, targets, rev_tensor = images.to(self.device), targets.to(self.device), rev_tensor.to(self.device)
             with torch.no_grad():
                 predicts = self.model(images)
@@ -250,7 +250,7 @@ class ModelValidator:
             avg_mAPs = {key: 100 * torch.mean(torch.stack(val)) for key, val in mAPs.items()}
             self.progress.one_batch(avg_mAPs)
 
-            predict_json.extend(predicts_to_json(img_paths, predicts, rev_tensor))
+            predict_json.extend(predicts_to_json(image_ids, predicts, rev_tensor))
         self.progress.finish_one_epoch(avg_mAPs, epoch_idx=epoch_idx)
         self.progress.visualize_image(images, targets, predicts, epoch_idx=epoch_idx)
 

--- a/yolo/utils/dataset_utils.py
+++ b/yolo/utils/dataset_utils.py
@@ -41,7 +41,7 @@ def create_image_metadata(
         labels_path: str
 ) -> Tuple[Dict[int, List], Dict[int, Dict], Dict[str, int]]:
     """
-    Returnes three dictionaries mapping image id to list of annotations, 
+    Returns three dictionaries mapping image id to list of annotations, 
     image id to image information, and image name to image id.
     Image id is the `int` `id` assigned to a image in the COCO formatted .json file.
 

--- a/yolo/utils/dataset_utils.py
+++ b/yolo/utils/dataset_utils.py
@@ -40,30 +40,29 @@ def locate_label_paths(dataset_path: Path, phase_name: Path) -> Tuple[Path, Path
 def create_image_metadata(labels_path: str) -> Tuple[Dict[str, List], Dict[str, Dict]]:
     """
     Create a dictionary containing image information and annotations
-    indexed by image name.
-
-    Image name is the file name of the image including the extension.
+    both indexed by image id. Image id is the file name without the extension.
+    It is not the same as the int image id saved in coco .json files.
 
     Args:
         labels_path (str): The path to the annotation json file.
 
     Returns:
         A Tuple of annotations_dict and image_info_dict.
-        annotations_dict is a dictionary where keys are image names and values
+        annotations_dict is a dictionary where keys are image ids and values
         are lists of annotations.
-        image_info_dict is a dictionary where keys are image file names and
+        image_info_dict is a dictionary where keys are image file id and
         values are image information dictionaries.
     """
     with open(labels_path, "r") as file:
         json_data = json.load(file)
         image_id_to_file_name_dict = {
-            img['id'] : Path(img["file_name"]).name for img in json_data["images"]
+            img['id'] : Path(img["file_name"]).stem for img in json_data["images"]
         }
         # TODO: id_to_idx is unnecessary. `idx = id - 1`` in coco as category_id starts from 1.
         # what if we had 1M images? Unnecessary!
         id_to_idx = discretize_categories(json_data.get("categories", [])) if "categories" in json_data else None
         annotations_dict = map_annotations_to_image_names(json_data, id_to_idx, image_id_to_file_name_dict)  # check lookup is a good name?
-        image_info_dict = {Path(img["file_name"]).name: img for img in json_data["images"]}
+        image_info_dict = {Path(img["file_name"]).stem: img for img in json_data["images"]}
         return annotations_dict, image_info_dict
 
 

--- a/yolo/utils/dataset_utils.py
+++ b/yolo/utils/dataset_utils.py
@@ -39,45 +39,64 @@ def locate_label_paths(dataset_path: Path, phase_name: Path) -> Tuple[Path, Path
 
 def create_image_metadata(labels_path: str) -> Tuple[Dict[str, List], Dict[str, Dict]]:
     """
-    Create a dictionary containing image information and annotations indexed by image ID.
+    Create a dictionary containing image information and annotations
+    indexed by image name.
+
+    Image name is the file name of the image including the extension.
 
     Args:
         labels_path (str): The path to the annotation json file.
 
     Returns:
-        - annotations_index: A dictionary where keys are image IDs and values are lists of annotations.
-        - image_info_dict: A dictionary where keys are image file names without extension and values are image information dictionaries.
+        A Tuple of annotations_dict and image_info_dict.
+        annotations_dict is a dictionary where keys are image names and values
+        are lists of annotations.
+        image_info_dict is a dictionary where keys are image file names and
+        values are image information dictionaries.
     """
     with open(labels_path, "r") as file:
-        labels_data = json.load(file)
-        id_to_idx = discretize_categories(labels_data.get("categories", [])) if "categories" in labels_data else None
-        annotations_index = organize_annotations_by_image(labels_data, id_to_idx)  # check lookup is a good name?
-        image_info_dict = {Path(img["file_name"]).stem: img for img in labels_data["images"]}
-        return annotations_index, image_info_dict
+        json_data = json.load(file)
+        image_id_to_file_name_dict = {
+            img['id'] : Path(img["file_name"]).name for img in json_data["images"]
+        }
+        # TODO: id_to_idx is unnecessary. `idx = id - 1`` in coco as category_id starts from 1.
+        # what if we had 1M images? Unnecessary!
+        id_to_idx = discretize_categories(json_data.get("categories", [])) if "categories" in json_data else None
+        annotations_dict = map_annotations_to_image_names(json_data, id_to_idx, image_id_to_file_name_dict)  # check lookup is a good name?
+        image_info_dict = {Path(img["file_name"]).name: img for img in json_data["images"]}
+        return annotations_dict, image_info_dict
 
 
-def organize_annotations_by_image(data: Dict[str, Any], id_to_idx: Optional[Dict[int, int]]):
+def map_annotations_to_image_names(
+        json_data: Dict[str, Any],
+        category_id_to_idx: Optional[Dict[int, int]],
+        image_id_to_image_name:dict[int, str]
+) -> dict[str, list[dict]]:
     """
-    Use image index to lookup every annotations
+    Returns a dict mapping image file names to a list of all corresponding annotations.
     Args:
-        data (Dict[str, Any]): A dictionary containing annotation data.
+        json_data: Data read from a COCO json file.
+        category_id_to_idx: For COCO dataset, a dict mapping from category_id
+            to (category_id - 1).  # TODO: depricate?
+        image_id_to_image_name: Dict mapping image_id to image_file name. 
 
     Returns:
-        Dict[int, List[Dict[str, Any]]]: A dictionary where keys are image IDs and values are lists of annotations.
-        Annotations with "iscrowd" set to True are excluded from the index.
-
+        image_name_to_annotation_dict_list: A dictionary where keys are image IDs
+            and values are lists of annotation dictionaries.
+            Annotations with "iscrowd" set to True, are excluded.
     """
-    annotation_lookup = {}
-    for anno in data["annotations"]:
-        if anno["iscrowd"]:
+    image_name_to_annotation_dict_list = {}
+    for annotation_dict in json_data["annotations"]:
+        if annotation_dict["iscrowd"]:
             continue
-        image_id = anno["image_id"]
-        if id_to_idx:
-            anno["category_id"] = id_to_idx[anno["category_id"]]
-        if image_id not in annotation_lookup:
-            annotation_lookup[image_id] = []
-        annotation_lookup[image_id].append(anno)
-    return annotation_lookup
+        image_id = annotation_dict["image_id"]
+        image_name = image_id_to_image_name[image_id]
+        if category_id_to_idx:
+            annotation_dict["category_id"] = category_id_to_idx[annotation_dict["category_id"]]
+        if image_name not in image_name_to_annotation_dict_list:
+            image_name_to_annotation_dict_list[image_name] = []
+        image_name_to_annotation_dict_list[image_name].append(annotation_dict)
+    return image_name_to_annotation_dict_list
 
 
 def scale_segmentation(

--- a/yolo/utils/model_utils.py
+++ b/yolo/utils/model_utils.py
@@ -160,10 +160,21 @@ def collect_prediction(predict_json: List, local_rank: int) -> List:
     return predict_json
 
 
-def predicts_to_json(image_ids, predicts, rev_tensor):
+def predicts_to_json(
+        image_ids:tuple[int],
+        predicts:list[Tensor],
+        rev_tensor:Tensor
+) -> list[dict[str, any]]:
     """
-    TODO: function document
-    turn a batch of imagepath and predicts(n x 6 for each image) to a List of diction(Detection output)
+    Returns a list of prediction dictionaries. Each dict contains, image_id,
+    category_id, bbox and score.
+
+    Args:
+        image_ids: Image ids obtained from COCO formatted .json files.
+        predicts: For each iamge, contains a tensor of shape (n, 6),
+            where n is the number of detected bbox in the corresponding image.
+        rev_tensor: A tensor of shape (m,5), where m is the number of images.
+            TODO: add docstring of what this is.
     """
     batch_json = []
     for image_id, bboxes, box_reverse in zip(image_ids, predicts, rev_tensor):

--- a/yolo/utils/model_utils.py
+++ b/yolo/utils/model_utils.py
@@ -161,7 +161,7 @@ def collect_prediction(predict_json: List, local_rank: int) -> List:
 
 
 def predicts_to_json(
-        image_ids:tuple[int],
+        image_ids:Union[tuple[int], tuple[str]],
         predicts:list[Tensor],
         rev_tensor:Tensor
 ) -> list[dict[str, any]]:
@@ -170,7 +170,9 @@ def predicts_to_json(
     category_id, bbox and score.
 
     Args:
-        image_ids: Image ids obtained from COCO formatted .json files.
+        image_ids: Tuple of image ids.
+            When using a COCO .json annotation file, image ids are int.
+            When using YOLO .txt annotation files, image ids are string. 
         predicts: For each iamge, contains a tensor of shape (n, 6),
             where n is the number of detected bbox in the corresponding image.
         rev_tensor: A tensor of shape (m,5), where m is the number of images.

--- a/yolo/utils/model_utils.py
+++ b/yolo/utils/model_utils.py
@@ -160,19 +160,19 @@ def collect_prediction(predict_json: List, local_rank: int) -> List:
     return predict_json
 
 
-def predicts_to_json(img_paths, predicts, rev_tensor):
+def predicts_to_json(image_ids, predicts, rev_tensor):
     """
     TODO: function document
     turn a batch of imagepath and predicts(n x 6 for each image) to a List of diction(Detection output)
     """
     batch_json = []
-    for img_path, bboxes, box_reverse in zip(img_paths, predicts, rev_tensor):
+    for image_id, bboxes, box_reverse in zip(image_ids, predicts, rev_tensor):
         scale, shift = box_reverse.split([1, 4])
         bboxes[:, 1:5] = (bboxes[:, 1:5] - shift[None]) / scale[None]
         bboxes[:, 1:5] = transform_bbox(bboxes[:, 1:5], "xyxy -> xywh")
         for cls, *pos, conf in bboxes:
             bbox = {
-                "image_id": int(Path(img_path).stem),
+                "image_id": image_id,
                 "category_id": IDX_TO_ID[int(cls)],
                 "bbox": [float(p) for p in pos],
                 "score": float(conf),


### PR DESCRIPTION
## Description
When using COCO dataset (.json files) the `image_id` is incorrectly derived from the image file name in multiple parts of the code base. It is assumed that once image file names are converted to `int`, they will be equal to the `image_id` stored in the .json files. This is incorrect. As a result, in practical datasets where image names contain non-int characters, the `calculate_ap` function fails. That is because the derived string `image_id` and the actual int `image_id` as defined in the .json files don't match anymore. This PR addresses this issue by making the following necessary changes.

### Changes:
* Accurate and consistent usage of `image_id` (as defined in COCO .json file) throughout code base.
* For COCO, `YoloDataset.data` now contains `int` `image_id` along with image path and labels data. Previously `self.data` didn't include `image_id` information.
* For YOLO `.txt` datasets, `YoloDataset.data` contains string `image_id`. `image_id` in this case is image file name without extension as before.
* `YoloDataset.__getitem__()` not returns `image_id`, instead of `image_path`. Context: Only the actual `int` id is needed when using the COCO formatted data set and a call to `calculate_ap` is made.
* `dataset_utils.create_image_metadata()` now returns three dicts instead of two. Returns three dictionaries mapping image id to list of annotations, image id to image information, and image name to image id Image id is the `int` `id` assigned to a image in the COCO formatted .json file. Context: This enables `filter_data` to handle `image_id` of COCO datasets accurately.
* Docstrings of all touched functions updated.


[Please include a summary of the changes and the related issue. (Just overwrite this session directly)]

## Type of Change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] The code follows the Python style guide.
- [x] Code and files are well organized.
- [x] All tests pass.
- [ ] New code is covered by tests.
- [x] The pull request is directed to the corresponding topic branch.

## Licensing:

By submitting this pull request, I confirm that:

- [x] My contribution is made under the MIT License.
- [x] I have not included any code from questionable or non-compliant sources (GPL, AGPL, ... etc).
- [x] I understand that all contributions to this repository must comply with the MIT License, and I promise that my contributions do not violate this license.
- [x] I have not used any code or content from sources that conflict with the MIT License or are otherwise legally questionable.

## Additional Information

